### PR TITLE
Update only when necessary; Revert to HSV color space

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "philips-hue-adapter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "philips-hue-adapter",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Mozilla IoT Philips Hue Adapter. Press the link button on your Hue bridge to pair lights.",
   "main": "index.js",
   "keywords": [

--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -37,10 +37,13 @@ class PhilipsHueProperty extends Property {
    * @return {Promise} a promise which resolves to the updated value.
    */
   setValue(value) {
+    let changed = this.value !== value;
     return new Promise(resolve => {
       this.setCachedValue(value);
       resolve(this.value);
-      this.device.notifyPropertyChanged(this);
+      if (changed) {
+        this.device.notifyPropertyChanged(this);
+      }
     });
   }
 }
@@ -163,7 +166,7 @@ class PhilipsHueDevice extends Device {
     if (this.properties.has('on')) {
       let onProp = this.properties.get('on');
       if (onProp.value !== light.state.on) {
-        onProp.setValue(light.state.on);
+        onProp.setCachedValue(light.state.on);
         super.notifyPropertyChanged(onProp);
       }
     }
@@ -171,8 +174,10 @@ class PhilipsHueDevice extends Device {
     if (this.properties.has('color')) {
       let color = xyBriToCSS(light.state.xy, light.state.bri);
       let colorProp = this.properties.get('color');
-      if (color !== colorProp.value) {
-        colorProp.setValue(color);
+      if (color.toUpperCase() !== colorProp.value.toUpperCase()) {
+        console.log('Update color', color, 'aka', light.state, 'from',
+                    colorProp.value);
+        colorProp.setCachedValue(color);
         super.notifyPropertyChanged(colorProp);
       }
     }
@@ -180,7 +185,7 @@ class PhilipsHueDevice extends Device {
     if (this.properties.has('level')) {
       let levelProp = this.properties.get('level');
       if (levelProp.value !== light.state.bri) {
-        levelProp.setValue(light.state.bri);
+        levelProp.setCachedValue(light.state.bri);
         super.notifyPropertyChanged(levelProp);
       }
     }


### PR DESCRIPTION
Mostly fixes interoperability issues with Hue app and other controllers.

Notably: the brightness (Y) of the CIE xyY color space calculation suggested by the Philips Hue API documentation appears to be incorrect. This may be a side effect of not constraining the xy coordinates to the bulb's color gamut. Until a more concerted effort can be made to figure out the root cause of the brightness drops, this PR reverts back to using the HSV color space.