### PR TITLE
Add support for non standard port 

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@
 const PhilipsHueAdapter = require('./philips-hue-adapter');
 const fetch = require('node-fetch');
 const SsdpClient = require('node-ssdp').Client;
+const url = require('url');
 
 const bridgeAdapters = {};
 
@@ -27,7 +28,7 @@ function ssdpSearch(adapterManager, manifest) {
     }
     // Normalize bridge id
     bridgeId = bridgeId.toLowerCase();
-    const bridgeIp = rinfo.address;
+    const bridgeIp = url.parse(headers['LOCATION']).host;
     if (bridgeAdapters[bridgeId]) {
       return;
     }

--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -391,8 +391,18 @@ class PhilipsHueAdapter extends Adapter {
 
     const apiBase = `http://${this.bridgeIp}/api/${this.username}`;
     return Promise.all([
-      fetch(`${apiBase}/lights`),
-      fetch(`${apiBase}/sensors`),
+      fetch(`${apiBase}/lights`).then(function(response) {
+        if (response.status == 404) {
+            return new fetch.Response("[]", {"status": "200"});
+        }
+        return response;
+      }),
+      fetch(`${apiBase}/sensors`).then(function(response) {
+        if (response.status == 404) {
+            return new fetch.Response("[]", {"status": "200"});
+        }
+        return response;
+      }),
     ]).then((responses) => {
       return Promise.all(responses.map((res) => res.json()));
     }).then(([lights, sensors]) => {


### PR DESCRIPTION
And also support for handling no sensors no lights case. In our case there were no sensors present in the bridge and the adapter was failing because of that.

There may be a better way to handle the 404 response from bridge. This is a quick fix. 

This PR solves #20 