### PR TITLE
Add property for battery

### DIFF
--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -273,6 +273,26 @@ class PhilipsHueDevice extends Device {
       }
     }
 
+    if (device.config.hasOwnProperty('battery')) {
+      this.properties.set(
+        'battery',
+        new PhilipsHueProperty(
+          this,
+          'battery',
+          {
+            '@type': 'LevelProperty',
+            label: 'Battery',
+            type: 'number',
+            unit: 'percent',
+            readOnly: true,
+            minimum: 0,
+            maximum: 100,
+          },
+          device.config.battery
+        )
+      );
+    }
+
     this.adapter.handleDeviceAdded(this);
   }
 
@@ -332,6 +352,15 @@ class PhilipsHueDevice extends Device {
       if (tempProp.value !== temp) {
         tempProp.setCachedValue(temp);
         super.notifyPropertyChanged(tempProp);
+      }
+    }
+
+    if (this.properties.has('battery')) {
+      const battery = device.config.battery;
+      const batteryProp = this.properties.get('battery');
+      if (batteryProp.value !== battery) {
+        batteryProp.setCachedValue(battery);
+        super.notifyPropertyChanged(batteryProp);
       }
     }
   }


### PR DESCRIPTION
This is split out from #32 at @mrstegeman 's request.

Main change compared to what was in #32 is that the property is also added to lamps, which should only apply to the hue go.