### PR TITLE
Use gateway's storage instead of node-persist

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,13 +46,28 @@
     "plugin": true,
     "exec": "{nodeLoader} {path}",
     "config": {
-      "usernames": {}
+      "usernames": []
     },
     "schema": {
       "type": "object",
       "properties": {
         "usernames": {
-          "type": "object"
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "username"
+            ],
+            "properties": {
+              "id": {
+                "type": "string"
+              },
+              "username": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
       "min": 2,
       "max": 2
     },
-    "enabled": true,
     "plugin": true,
     "exec": "{nodeLoader} {path}",
     "config": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "philips-hue-adapter",
   "display_name": "Philips Hue",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Mozilla IoT Philips Hue Adapter. Press the link button on your Hue bridge to pair devices.",
   "main": "index.js",
   "keywords": [
@@ -40,10 +40,22 @@
   ],
   "moziot": {
     "api": {
-      "min": 1,
+      "min": 2,
       "max": 2
     },
+    "enabled": true,
     "plugin": true,
-    "exec": "{nodeLoader} {path}"
+    "exec": "{nodeLoader} {path}",
+    "config": {
+      "usernames": {}
+    },
+    "schema": {
+      "type": "object",
+      "properties": {
+        "usernames": {
+          "type": "object"
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
Takes any place we were getting known bridge usernames from node-persist and uses the addon config database instead.

Should fix any issues with persistence of bridge usernames.