### PR TITLE
Make temperature sensor be a temperature sensor

### DIFF
--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -199,8 +199,8 @@ class PhilipsHueDevice extends Device {
             },
             device.state.presence));
       } else if (device.state.hasOwnProperty('temperature')) {
-        // TODO: Fill in proper types once they are implemented
         this.type = Constants.THING_TYPE_UNKNOWN_THING;
+        this['@type'] = ['TemperatureSensor'];
         this.properties.set(
           'temperature',
           new PhilipsHueProperty(
@@ -209,11 +209,13 @@ class PhilipsHueDevice extends Device {
             {
               label: 'Temperature',
               type: 'number',
+              '@type': 'TemperatureProperty',
               unit: 'degree celsius',
               readOnly: true,
             },
             device.state.temperature / 100));
       } else if (device.state.hasOwnProperty('daylight')) {
+        // TODO: Fill in proper types once they are implemented
         this.type = Constants.THING_TYPE_BINARY_SENSOR;
         this['@type'] = ['BinarySensor'];
         this.properties.set(


### PR DESCRIPTION
The motion sensor also exposes a temperature sensor (which as tracked in bug #25 are exposed as separate things). This makes it annotated as temperature sensor for a nice UI experience:

![image](https://user-images.githubusercontent.com/640949/51405298-44633300-1b56-11e9-9ba2-3a58b88c9e76.png)
