### PR TITLE
Handle missing device.config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "philips-hue-adapter",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -759,9 +759,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "philips-hue-adapter",
   "display_name": "Philips Hue",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Mozilla WebThings Gateway Philips Hue Adapter. Press the link button on your Hue bridge to pair devices.",
   "main": "index.js",
   "keywords": [

--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -334,7 +334,7 @@ class PhilipsHueDevice extends Device {
       }
     }
 
-    if (device.config.hasOwnProperty('battery')) {
+    if (device.config && device.config.hasOwnProperty('battery')) {
       this.properties.set(
         'battery',
         new PhilipsHueProperty(


### PR DESCRIPTION
Under some cases a device's json data lacks the config property

Fixes #38