### PR TITLE
Prevent false positive change detections on null and false

### DIFF
--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -87,6 +87,10 @@ class PhilipsHueProperty extends Property {
       value = Math.round(value);
     }
 
+    if(this.type === 'boolean') {
+      value = !!value;
+    }
+
     const changed = this.value !== value;
     return new Promise((resolve) => {
       this.setCachedValue(value);


### PR DESCRIPTION
The `setCachedValue` converts `null` to `false`.
This breaks the `this.value !== value` check.
Therefore the addon propagates changes every second (poll cycle).