### PR TITLE
Support monochromatic (brightness-only) Hue lights

### DIFF
--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -346,6 +346,25 @@ class PhilipsHueDevice extends Device {
                 maximum: 100,
               },
               level));
+        } else {
+          this['@type'].push('BrightnessProperty');
+
+          const level = stateToLevel(device.state);
+
+          this.properties.set(
+            'level',
+            new PhilipsHueProperty(
+              this,
+              'level',
+              {
+                '@type': 'BrightnessProperty',
+                label: 'Brightness',
+                type: 'integer',
+                unit: 'percent',
+                minimum: 0,
+                maximum: 100,
+              },
+              level));
         }
       }
     }

--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -347,8 +347,6 @@ class PhilipsHueDevice extends Device {
               },
               level));
         } else {
-          this['@type'].push('BrightnessProperty');
-
           const level = stateToLevel(device.state);
 
           this.properties.set(


### PR DESCRIPTION
Phillips offers a [few lights that only support dimming](meethue.com/en-us/p/e26/046677530389). Currently, the addon only supports turning them on and off. This PR should add dimming support for these lights.