### PR TITLE
Add precision to temperature sensors

### DIFF
--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -296,6 +296,7 @@ class PhilipsHueDevice extends Device {
               '@type': 'TemperatureProperty',
               unit: 'degree celsius',
               readOnly: true,
+              multipleOf: 0.1,
             },
             device.state.temperature / 100
           )


### PR DESCRIPTION
Uses https://github.com/mozilla-iot/gateway/pull/1971 to set the precision to one decimal place for the temperature sensor in the hue motion sensor.