### PR TITLE
Fix to detect individual key presses of hue dimmer switches utilising…

### DIFF
--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -384,20 +384,20 @@ class PhilipsHueDevice extends Device {
                     device.state.buttonevent <= buttonInfo.longRelease
                 )
               );
-              this.properties.set(
-                'lastUpdated',
-                new PhilipsHueProperty(
-                  this,
-                  buttonType,
-                  {
-                    label: buttonInfo.label,
-                    type: 'date',
-                    readOnly: true,
-                  },
-                  device.state.lastupdated
-                )
-              );
             }
+            this.properties.set(
+              'lastUpdated',
+              new PhilipsHueProperty(
+                this,
+                'lastUpdated',
+                {
+                  label: `Last Updated`,
+                  type: 'string',
+                  readOnly: true,
+                },
+                device.state.lastupdated
+              )
+            );
           }
         }
       }
@@ -622,7 +622,7 @@ class PhilipsHueDevice extends Device {
           }
         }
       }
-      lastUpdatedProp.setCachedValue(lastUpdated);
+      lastUpdatedProp.setCachedValueAndNotify(lastUpdated);
     }
   }
 

--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -166,7 +166,7 @@ class PhilipsHueProperty extends Property {
         );
         break;
       }
-      case 'lastupdated': {
+      case 'lastUpdated': {
         this.device.adapter.sendProperties(
           this.device.deviceId,
           value
@@ -607,21 +607,22 @@ class PhilipsHueDevice extends Device {
       const buttonEvent = device.state.buttonevent;
       const lastUpdated = device.state.lastupdated;
       const lastUpdatedProp = this.properties.get('lastUpdated');
+      const isPressed = lastUpdatedProp.value !== lastUpdated;
 
       for (const buttonType in HUE_DIMMER_SWITCH_BUTTONS) {
         if (HUE_DIMMER_SWITCH_BUTTONS.hasOwnProperty(buttonType)) {
           const buttonInfo = HUE_DIMMER_SWITCH_BUTTONS[buttonType];
           const buttonProp = this.properties.get(buttonType);
-
-          const pressed = buttonEvent >= buttonInfo.initialPress &&
+          const isButton = buttonEvent >= buttonInfo.initialPress &&
             buttonEvent <= buttonInfo.longRelease;
 
-          buttonProp.setCachedValueAndNotify(pressed &&
-            lastUpdatedProp.value !== lastUpdated);
+
+          if (buttonProp.value !== (isPressed && isButton)) {
+            buttonProp.setCachedValueAndNotify(isPressed && isButton);
+          }
         }
       }
-
-      lastUpdatedProp.setCachedValueAndNotify(lastUpdated);
+      lastUpdatedProp.setCachedValue(lastUpdated);
     }
   }
 

--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -395,7 +395,7 @@ class PhilipsHueDevice extends Device {
                     type: 'date',
                     readOnly: true,
                   },
-                  device.state.lastupdated                  
+                  device.state.lastupdated
                 )
               );
             }
@@ -608,16 +608,17 @@ class PhilipsHueDevice extends Device {
       const buttonevent = device.state.buttonevent;
       const lastupdated = device.state.lastupdated;
       const lastupdatedProp = this.properties.get('lastupdated');
-          
+
       for (const buttonType in HUE_DIMMER_SWITCH_BUTTONS) {
         if (HUE_DIMMER_SWITCH_BUTTONS.hasOwnProperty(buttonType)) {
           const buttonInfo = HUE_DIMMER_SWITCH_BUTTONS[buttonType];
           const buttonProp = this.properties.get(buttonType);
-          
+
           const pressed = buttonevent >= buttonInfo.initial_press &&
             buttonevent <= buttonInfo.long_release;
 
-          buttonProp.setCachedValueAndNotify(pressed && lastupdatedProp.value !== lastupdated);
+          buttonProp.setCachedValueAndNotify(pressed &&
+            lastupdatedProp.value !== lastupdated);
         }
       }
 

--- a/philips-hue-adapter.js
+++ b/philips-hue-adapter.js
@@ -32,31 +32,31 @@ const SUPPORTED_SENSOR_TYPES = {
 
 const HUE_DIMMER_SWITCH_BUTTONS = {
   buttonOn: {
-    initial_press: 1000,
+    initialPress: 1000,
     repeat: 1001,
-    short_release: 1002,
-    long_release: 1003,
+    shortRelease: 1002,
+    longRelease: 1003,
     label: 'On',
   },
   buttonBrighten: {
-    initial_press: 2000,
+    initialPress: 2000,
     repeat: 2001,
-    short_release: 2002,
-    long_release: 2003,
+    shortRelease: 2002,
+    longRelease: 2003,
     label: 'Dim up',
   },
   buttonDim: {
-    initial_press: 3000,
+    initialPress: 3000,
     repeat: 3001,
-    short_release: 3002,
-    long_release: 3003,
+    shortRelease: 3002,
+    longRelease: 3003,
     label: 'Dim down',
   },
   buttonOff: {
-    initial_press: 4000,
+    initialPress: 4000,
     repeat: 4001,
-    short_release: 4002,
-    long_release: 4003,
+    shortRelease: 4002,
+    longRelease: 4003,
     label: 'Off',
   },
 };
@@ -380,17 +380,16 @@ class PhilipsHueDevice extends Device {
                     type: 'boolean',
                     readOnly: true,
                   },
-                  device.state.buttonevent >= buttonInfo.initial_press &&
-                    device.state.buttonevent <= buttonInfo.long_release
+                  device.state.buttonevent >= buttonInfo.initialPress &&
+                    device.state.buttonevent <= buttonInfo.longRelease
                 )
               );
               this.properties.set(
-                'lastupdated',
+                'lastUpdated',
                 new PhilipsHueProperty(
                   this,
                   buttonType,
                   {
-                    '@type': 'LastUpdatedProperty',
                     label: buttonInfo.label,
                     type: 'date',
                     readOnly: true,
@@ -605,24 +604,24 @@ class PhilipsHueDevice extends Device {
     }
 
     if (this.properties.has('buttonOn')) {
-      const buttonevent = device.state.buttonevent;
-      const lastupdated = device.state.lastupdated;
-      const lastupdatedProp = this.properties.get('lastupdated');
+      const buttonEvent = device.state.buttonevent;
+      const lastUpdated = device.state.lastupdated;
+      const lastUpdatedProp = this.properties.get('lastUpdated');
 
       for (const buttonType in HUE_DIMMER_SWITCH_BUTTONS) {
         if (HUE_DIMMER_SWITCH_BUTTONS.hasOwnProperty(buttonType)) {
           const buttonInfo = HUE_DIMMER_SWITCH_BUTTONS[buttonType];
           const buttonProp = this.properties.get(buttonType);
 
-          const pressed = buttonevent >= buttonInfo.initial_press &&
-            buttonevent <= buttonInfo.long_release;
+          const pressed = buttonEvent >= buttonInfo.initialPress &&
+            buttonEvent <= buttonInfo.longRelease;
 
           buttonProp.setCachedValueAndNotify(pressed &&
-            lastupdatedProp.value !== lastupdated);
+            lastUpdatedProp.value !== lastUpdated);
         }
       }
 
-      lastupdatedProp.setCachedValueAndNotify(lastupdated);
+      lastUpdatedProp.setCachedValueAndNotify(lastUpdated);
     }
   }
 


### PR DESCRIPTION
… lastupdated property

This PR enables better detection of hue dimmer switch button presses by comparing the lastupdated property as reported by the hue bridge api.

Thanks to https://www.hackster.io/robin-cole/hijack-a-hue-remote-to-control-anything-with-home-assistant-5239a4 for the info.

"We actually require two RESTful sensors, one to monitor the "buttonevent" and one to monitor "lastupdated", since we want to detect every push of a button and "buttonevent" will not change if the same button is pressed twice in a row."